### PR TITLE
update to work for all the channels on lxplus (back to py2)

### DIFF
--- a/plotter/functions.cc
+++ b/plotter/functions.cc
@@ -180,6 +180,12 @@ float DPhi_CMLep_Zboost(float l_pt, float l_eta, float l_phi, float l_M, float l
   return deltaPhi(l1.Phi(),Z.Phi());
 }
 
+float eFromPt(float pt, float eta, float phi, float m) {
+  typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> > PtEtaPhiMVector;
+  PtEtaPhiMVector p4(pt,eta,phi,m);
+  return p4.E();
+}
+
 
 //PU weights
 

--- a/plotter/hwh-gen/cuts.txt
+++ b/plotter/hwh-gen/cuts.txt
@@ -1,0 +1,7 @@
+alwaystrue : 1
+nFwdJ      : nGenFwdQ > 0
+nT         : nGenTop > 0
+FwdJ_acc   : GenFwdQ_pt[0] > 30 && abs(GenFwdQ_eta[0]) > 2.5 && eFromPt(GenFwdQ_pt[0],GenFwdQ_eta[0],GenFwdQ_phi[0],GenFwdQ_mass[0]) > 300
+Top_acc1   : GenTop_pt[0] > 120
+Top_acc2   : GenTop_pt[0] > 300
+

--- a/plotter/hwh-gen/mca-signals.txt
+++ b/plotter/hwh-gen/mca-signals.txt
@@ -1,0 +1,7 @@
+ww1l+   :  pp-tjww-1l   : 0.00299   ; FillColor=ROOT.kAzure+1
+ww2l+   :  pp-tjww-2l   : 0.00051   ; FillColor=ROOT.kAzure+2
+wz1l+   :  pp-tjwz-123l : 0.00555  :  nGenDressedLepton==1 ; FillColor=ROOT.kRed+1
+wz2l+   :  pp-tjwz-123l : 0.00555  :  nGenDressedLepton==2 ; FillColor=ROOT.kRed+2
+wz3l+   :  pp-tjwz-123l : 0.00555  :  nGenDressedLepton==3 ; FillColor=ROOT.kRed+3
+zz2l+   :  pp-tjzz-24l  : 0.00052  :  nGenDressedLepton==2 ; FillColor=ROOT.kGreen+2
+zz4l+   :  pp-tjzz-24l  : 0.00052  :  nGenDressedLepton==4 ; FillColor=ROOT.kGreen+4

--- a/plotter/tree2yield.py
+++ b/plotter/tree2yield.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 from math import *
 import re
 import os, os.path
@@ -310,14 +311,14 @@ class TreeToYield:
         if 'Friends' in self._settings: friendOpts += self._settings['Friends']
         if 'FriendsSimple' in self._settings: friendOpts += [ ('sf/t', d+"/evVarFriend_{cname}.root") for d in self._settings['FriendsSimple'] ]
         for tf_tree,tf_file in friendOpts:
-#            print 'Adding friend',tf_tree,tf_file
+            #print ('Adding friend',tf_tree,tf_file)
             basepath = None
             for treepath in getattr(self._options, 'path', []):
-                if self._cname in os.listdir(treepath):
+                if self._cname+'.root' in os.listdir(treepath):
                     basepath = treepath
                     break
             if not basepath:
-                raise RuntimeError("%s -- ERROR: %s process not found in paths (%s)" % (__name__, cname, repr(options.path)))
+                raise RuntimeError("%s -- ERROR: %s process not found in paths (%s)" % (__name__, self._cname, repr(options.path)))
 
             tf_filename = tf_file.format(name=self._name, cname=self._cname, P=basepath)
             tf = self._tree.AddFriend(tf_tree, tf_filename),


### PR DESCRIPTION
Also modify the base mcAnalysis to work simplified:

- there is 1 ROOT file / component, all in the same directory (the one given by -P)
- the friends are in the -P basepath + /friends/ directory
- if there is no counters.txt, the normalization is done simply with the tree->GetEntries(). It does not account sum(weigths) and skims for now

I did first GEN tables with the command:

python mcAnalysis.py -P eos_nanogen -F Friends "{P}/friends/{cname}_Friend.root" --s2v hwh-gen/mca-signals.txt hwh-gen/cuts.txt -l 137 -G